### PR TITLE
Задание к уроку "Rack-интерфейс"

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,14 +9,14 @@ class App
     body = response_body(formatter)
     status = formatter.valid? ? 200 : 400
 
-    [status, { }, [body]]
+    [status, {}, [body]]
   end
 
   private
 
   def response_body(formatter)
     if formatter.valid?
-      formatter.time + "\n"
+      "#{formatter.time}\n"
     else
       "Unknown time format [#{formatter.invalid_formats.join(', ')}]\n"
     end

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# A minimal Rack application that returns UTC time in requested format.
+class App
+  def call(env)
+    @request = Rack::Request.new(env)
+    [status, headers, body]
+  end
+
+  def body
+    [response_body]
+  end
+
+  private
+
+  def valid_request?
+    @request.path == '/time' && @request.get? && format_present?
+  end
+
+  def format_present?
+    !formats.empty?
+  end
+
+  def formats
+    param = @request.params['format']
+    return [] if param.nil? || param.strip.empty?
+    param.split(',').map(&:strip)
+  end
+
+  def valid_formats
+    %w[year month day hour minute second]
+  end
+
+  def invalid_formats
+    formats - valid_formats
+  end
+
+  def formatted_time
+    now = Time.now.utc
+    formats.map { |f| send("format_#{f}", now) }.join('-')
+  end
+
+  def format_year(now)
+    now.year.to_s
+  end
+
+  def format_month(now)
+    format('%02d', now.month)
+  end
+
+  def format_day(now)
+    format('%02d', now.day)
+  end
+
+  def format_hour(now)
+    format('%02d', now.hour)
+  end
+
+  def format_minute(now)
+    format('%02d', now.min)
+  end
+
+  def format_second(now)
+    format('%02d', now.sec)
+  end
+
+  def status
+    return 404 unless @request.path == '/time' && @request.get?
+    return 400 if invalid_formats.any? || !format_present?
+    200
+  end
+
+  def headers
+    { 'Content-Type' => 'text/plain' }
+  end
+
+  def response_body
+    case status
+    when 200
+      "#{formatted_time}\n"
+    when 400
+      if invalid_formats.any?
+        "Unknown time format [#{invalid_formats.join(', ')}]\n"
+      else
+        "Unknown time format []\n"
+      end
+    when 404
+      "Not Found\n"
+    end
+  end
+end

--- a/app.rb
+++ b/app.rb
@@ -3,89 +3,22 @@
 # A minimal Rack application that returns UTC time in requested format.
 class App
   def call(env)
-    @request = Rack::Request.new(env)
-    [status, headers, body]
-  end
+    request = Rack::Request.new(env)
+    formatter = TimeFormatter.new(request.params['format'])
 
-  def body
-    [response_body]
+    body = response_body(formatter)
+    status = formatter.valid? ? 200 : 400
+
+    [status, { }, [body]]
   end
 
   private
 
-  def valid_request?
-    @request.path == '/time' && @request.get? && format_present?
-  end
-
-  def format_present?
-    !formats.empty?
-  end
-
-  def formats
-    param = @request.params['format']
-    return [] if param.nil? || param.strip.empty?
-    param.split(',').map(&:strip)
-  end
-
-  def valid_formats
-    %w[year month day hour minute second]
-  end
-
-  def invalid_formats
-    formats - valid_formats
-  end
-
-  def formatted_time
-    now = Time.now.utc
-    formats.map { |f| send("format_#{f}", now) }.join('-')
-  end
-
-  def format_year(now)
-    now.year.to_s
-  end
-
-  def format_month(now)
-    format('%02d', now.month)
-  end
-
-  def format_day(now)
-    format('%02d', now.day)
-  end
-
-  def format_hour(now)
-    format('%02d', now.hour)
-  end
-
-  def format_minute(now)
-    format('%02d', now.min)
-  end
-
-  def format_second(now)
-    format('%02d', now.sec)
-  end
-
-  def status
-    return 404 unless @request.path == '/time' && @request.get?
-    return 400 if invalid_formats.any? || !format_present?
-    200
-  end
-
-  def headers
-    { 'Content-Type' => 'text/plain' }
-  end
-
-  def response_body
-    case status
-    when 200
-      "#{formatted_time}\n"
-    when 400
-      if invalid_formats.any?
-        "Unknown time format [#{invalid_formats.join(', ')}]\n"
-      else
-        "Unknown time format []\n"
-      end
-    when 404
-      "Not Found\n"
+  def response_body(formatter)
+    if formatter.valid?
+      formatter.time + "\n"
+    else
+      "Unknown time format [#{formatter.invalid_formats.join(', ')}]\n"
     end
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative 'app'
+
+run App.new

--- a/config.ru
+++ b/config.ru
@@ -5,7 +5,7 @@ require_relative 'app'
 
 ROUTES = {
   '/time' => App.new
-}
+}.freez
 
 use Rack::ContentType, 'text/plain'
 run Rack::URLMap.new(ROUTES)

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require_relative 'lib/time_formatter'
 require_relative 'app'
 
-run App.new
+ROUTES = {
+  '/time' => App.new
+}
+
+use Rack::ContentType, 'text/plain'
+run Rack::URLMap.new(ROUTES)

--- a/lib/time_formatter.rb
+++ b/lib/time_formatter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# A formatter class that validates time format components and produces formatted UTC time.
+class TimeFormatter
+  VALID_FORMATS = %w[year month day hour minute second].freeze
+
+  def initialize(format_param)
+    @format_param = format_param
+  end
+
+  def valid?
+    invalid_formats.empty?
+  end
+
+  def time
+    now = Time.now.utc
+    formats.map { |f| send("format_#{f}", now) }.join('-')
+  end
+
+  def invalid_formats
+    return [''] if @format_param.nil? || @format_param.strip.empty?
+    formats - VALID_FORMATS
+  end
+
+  private
+
+  def formats
+    return [] if @format_param.nil? || @format_param.strip.empty?
+
+    @format_param.split(',').map(&:strip)
+  end
+
+  def format_year(now)
+    now.year.to_s
+  end
+
+  def format_month(now)
+    format('%02d', now.month)
+  end
+
+  def format_day(now)
+    format('%02d', now.day)
+  end
+
+  def format_hour(now)
+    format('%02d', now.hour)
+  end
+
+  def format_minute(now)
+    format('%02d', now.min)
+  end
+
+  def format_second(now)
+    format('%02d', now.sec)
+  end
+end

--- a/lib/time_formatter.rb
+++ b/lib/time_formatter.rb
@@ -19,6 +19,7 @@ class TimeFormatter
 
   def invalid_formats
     return [''] if @format_param.nil? || @format_param.strip.empty?
+
     formats - VALID_FORMATS
   end
 


### PR DESCRIPTION
## Минималистичное Rack приложение
Отвечает на URL GET /time с параметром строки запроса format и возвращать время в заданном формате.

Например, GET-запрос
`/time?format=year%2Cmonth%2Cday`
вернет ответ с типом `text/plain` и телом `1970-01-01`.


Доступные форматы времени:
- year
- month
- day
- hour
- minute
- second

Форматы передаются в параметре строки запроса format в любом порядке

Если среди форматов времени присутствует неизвестный формат, необходимо возвращать ответ с кодом статуса `400` и телом `"Unknown time format [epoch]"`

Если неизвестных форматов несколько, все они должны быть перечислены в теле ответа, например: `"Unknown time format [epoch, age]"`

При запросе на любой другой URL необходимо возвращать ответ с кодом статуса `404`
